### PR TITLE
Update dependencies to latest versions as at July 20 2022

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,9 +6,11 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta name="description" content="Markdown Pages - a simple template for Markdown-based sites on GitHub Pages">
 	<link rel="shortcut icon" type="image/png" href="assets/user/favicon.png"/>
-	<link rel="stylesheet" href="https://unpkg.com/@picocss/pico@1.4.4/css/pico.min.css">
-	<script src="https://unpkg.com/@highlightjs/cdn-assets@11.4.0/highlight.min.js"></script>
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/showdown/1.9.1/showdown.min.js" integrity="sha512-L03kznCrNOfVxOUovR6ESfCz9Gfny7gihUX/huVbQB9zjODtYpxaVtIaAkpetoiyV2eqWbvxMH9fiSv5enX7bw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+
+	<link rel="stylesheet" href="https://unpkg.com/@picocss/pico@latest/css/pico.min.css" integrity="sha512-2MD814AVKlRmLMNeIKnmSSJEaI1gFz742oiIWCkRDZ3ZoN8lALOPN71gCCya8WItuZNfrulKl5jnLOVIhtGY+A==" crossorigin="anonymous">
+  	<script src="https://unpkg.com/@highlightjs/cdn-assets@11.6.0/highlight.min.js" integrity="sha512-gU7kztaQEl7SHJyraPfZLQCNnrKdaQi5ndOyt4L4UPL/FHDd/uB9Je6KDARIqwnNNE27hnqoWLBq+Kpe4iHfeQ==" crossorigin="anonymous"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/showdown/2.1.0/showdown.min.js" integrity="sha512-LhccdVNGe2QMEfI3x4DVV3ckMRe36TfydKss6mJpdHjNFiV07dFpS2xzeZedptKZrwxfICJpez09iNioiSZ3hA==" crossorigin="anonymous"></script>
+
 	<title>Markdown Pages</title>
 	<style>
 		/**** style overrides *****/
@@ -83,10 +85,10 @@ function setHighlightTheme(mode) {
 	link.rel = 'stylesheet'; 
 	link.type = 'text/css';
 	if (mode == "light") {
-		link.href = 'https://unpkg.com/@highlightjs/cdn-assets@11.4.0/styles/atom-one-light.min.css'; 
+		link.href = 'https://unpkg.com/@highlightjs/cdn-assets@11.6.0/styles/atom-one-light.min.css'; 
 	}
 	if (mode == "dark") {
-		link.href = 'https://unpkg.com/@highlightjs/cdn-assets@11.4.0/styles/monokai-sublime.min.css'; 
+		link.href = 'https://unpkg.com/@highlightjs/cdn-assets@11.6.0/styles/monokai-sublime.min.css'; 
 	}
 	head.appendChild(link);
 }


### PR DESCRIPTION
Update dependencies and add SRI hashes. Update linked stylesheets for dark/light modes to highlight.js 11.6 (was 11.4)